### PR TITLE
full support for mobilenet training and int32 data types

### DIFF
--- a/TensorIOTensorFlow.podspec
+++ b/TensorIOTensorFlow.podspec
@@ -8,13 +8,13 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TensorIOTensorFlow'
-  s.version          = '0.1.1'
+  s.version          = '0.2.0'
   s.summary          = 'The TensorFlow (unofficial) build used by TensorIO for iOS.'
   s.description      = 'An unofficial build of TensorFlow for iOS used by TensorIO, supporting inference, evaluation, and training.'
   s.homepage         = 'https://github.com/doc-ai/tensorio-tensorflow-ios'
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.author           = { 'doc.ai' => 'philip@doc.ai' }
-  s.source           = { :http => 'https://storage.googleapis.com/tensorio-build/TensorIO-TensorFlow-1.13_0.1.1.tar.gz' }
+  s.source           = { :http => 'https://storage.googleapis.com/tensorio-build/TensorIO-TensorFlow-1.13_0.2.0.tar.gz' }
 
   s.ios.deployment_target = '9.3'
   s.library = 'c++'


### PR DESCRIPTION
Sources a significantly larger build of TensorFlow for iOS with support for full network training of a mobilenet model and int32 data types registered with all supported kernels.