### PR TITLE
v1.13.4 release information to match major.minor to tensorflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # TensorIOTensorFlow
 
-Unofficial TensorFlow cocoapod for iOS with support for inference, evaluation, and training. We use this pod in [TensorIO](https://github.com/doc-ai/tensorio-ios).
+Unofficial TensorFlow cocoapod for iOS with support for inference, evaluation, and training. Pod targets simluator and arm64 devices only (iOS 12.0+) with full support for training MobileNetV2 models on device. We use this pod in [TensorIO](https://github.com/doc-ai/tensorio-ios).
 
-Build: TensorFlow 1.13rc2.
+- Latest: v1.13.4
+- TensorFlow Build: 1.13rc2.
+
+The major.minor version number of this pod tracks the major.minor version of the build of TensorFlow it includes. We reserve our patch numbers for our own changes to the build, which  normally involves whitelisting additinal ops to support new models.
 
 ## Requirements
 

--- a/TensorIOTensorFlow.podspec
+++ b/TensorIOTensorFlow.podspec
@@ -8,13 +8,13 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TensorIOTensorFlow'
-  s.version          = '0.3.1'
+  s.version          = '1.13.4'
   s.summary          = 'The TensorFlow (unofficial) build used by TensorIO for iOS.'
   s.description      = 'An unofficial build of TensorFlow for iOS used by TensorIO, supporting inference, evaluation, and training.'
   s.homepage         = 'https://github.com/doc-ai/tensorio-tensorflow-ios'
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.author           = { 'doc.ai' => 'philip@doc.ai' }
-  s.source           = { :http => 'https://storage.googleapis.com/tensorio-build/TensorIO-TensorFlow-1.13_0.3.1.tar.gz' }
+  s.source           = { :http => 'https://storage.googleapis.com/tensorio-build/TensorIO-TensorFlow-1.13_4.tar.gz' }
 
   s.ios.deployment_target = '12.0'
   s.library = 'c++'

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ TENSORFLOW_1_13_0=tensorflow_1.13_4     # begin new version scheme, identifical 
 TENSORFLOW_0_3=tensorflow_0.3.0         # last 0.x version
 
 
-LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/tensorflow
+LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/$TENSORFLOW_1_13_0
 LIB_PROTOBUF_URL=$TENSORIO_BUILD_URL/libprotobuf
 LIB_NSYNC_URL=$TENSORIO_BUILD_URL/nsync
 

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,14 @@
 
 TENSORIO_BUILD_URL=https://storage.googleapis.com/tensorio-build
 
+
+# ordered newest to oldest
+# library is stored on goolge with name tensorflow_tf.version_our.version
+
+TENSORFLOW_1_13_0=tensorflow_1.13_4     # begin new version scheme, identifical to 0.3
+TENSORFLOW_0_3=tensorflow_0.3.0         # last 0.x version
+
+
 LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/tensorflow
 LIB_PROTOBUF_URL=$TENSORIO_BUILD_URL/libprotobuf
 LIB_NSYNC_URL=$TENSORIO_BUILD_URL/nsync


### PR DESCRIPTION
Same thing. Rationalizing releases to match the major.minor version of tensorflow we're using while reserving patch for our own changes.

Note this is patch 4, which I should have used for the tensorflow-ios-framework but i started it with patch 0. I'll match both to patch 5 with the next update.