### PR TITLE
R2.0 xc config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Unofficial TensorFlow cocoapod for iOS with support for inference, evaluation, and training. Pod targets simluator and arm64 devices only (iOS 12.0+) with full support for training MobileNetV2 models on device. We use this pod in [TensorIO](https://github.com/doc-ai/tensorio-ios).
 
-- Latest: v2.0.2
+- Latest: v2.0.3
 - TensorFlow Build: r2.0, v2.0.2
 
 The major.minor version number of this pod tracks the major.minor version of the build of TensorFlow it includes. We reserve our patch numbers for our own changes to the build, which  normally involves whitelisting additinal ops to support new models.
@@ -27,6 +27,29 @@ Based on doc.ai's [tensorflow-ios-framework](https://github.com/doc-ai/tensorflo
 - [tensorflow.a](https://storage.googleapis.com/tensorio-build/r2.0/tensorflow)
 - [libprotobuf.a](https://storage.googleapis.com/tensorio-build/r2.0/libprotobuf)
 - [libnsync.a](https://storage.googleapis.com/tensorio-build/r2.0/nsync)
+
+For projects that use this pod be sure to add the following to your header search paths and linker flags:
+
+**Header Search Paths:**
+
+```
+${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/Headers
+```
+
+**Linker Flags:**
+
+```
+-force_load "${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow"
+```
+
+If you are using Tensor/IO with this backend, these are already added to your project. If you are developing your own pod with TensorIOTensorFlow as a dependency, you can add the following to your podspec to do this automatically:
+
+```rb
+s.xcconfig = {
+  'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/Headers"',
+  'OTHER_LDFLAGS' => '-force_load "${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow"'
+}
+```
 
 ## Build
 

--- a/TensorIOTensorFlow.podspec
+++ b/TensorIOTensorFlow.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TensorIOTensorFlow'
-  s.version          = '2.0.2'
+  s.version          = '2.0.3'
   s.summary          = 'The TensorFlow (unofficial) build used by TensorIO for iOS.'
   s.description      = 'An unofficial build of TensorFlow for iOS used by TensorIO, supporting inference, evaluation, and training.'
   s.homepage         = 'https://github.com/doc-ai/tensorio-tensorflow-ios'

--- a/TensorIOTensorFlow.podspec
+++ b/TensorIOTensorFlow.podspec
@@ -28,9 +28,4 @@ Pod::Spec.new do |s|
     'Libraries/libnsync.a',
     'Libraries/libprotobuf.a'
   ]
-
-  s.xcconfig = {
-    'HEADER_SEARCH_PATHS' => '"${SRCROOT}/Pods/TensorIOTensorFlow/Frameworks/tensorflow.framework/Headers"',
-    'OTHER_LDFLAGS' => '-force_load "${SRCROOT}/Pods/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow" "-L ${SRCROOT}/Pods/TensorIOTensorFlow/Frameworks/tensorflow.framework"'
-  }
 end


### PR DESCRIPTION
The header search paths and linker flags should only be a part of the project that relies on this dependency on not of this pod itself.